### PR TITLE
일일 근로자 비교 및 그 외

### DIFF
--- a/src/component/context/TableContext.jsx
+++ b/src/component/context/TableContext.jsx
@@ -2,12 +2,13 @@ import { createContext, useContext } from "react";
 
 const TableContext = createContext({
     setCheckedList: () => {},
+    nonEditSelect: {},
 });
 
-export const TableProvider = ({children, setCheckedList}) => {
+export const TableProvider = ({children, setCheckedList, nonEditSelect}) => {
 
     return(
-        <TableContext.Provider value={{setCheckedList}}>
+        <TableContext.Provider value={{setCheckedList, nonEditSelect}}>
             {children}
         </TableContext.Provider>
     );

--- a/src/component/layout/content/management/compare/DailyCompareReducer.js
+++ b/src/component/layout/content/management/compare/DailyCompareReducer.js
@@ -55,6 +55,16 @@ const DailyCompareReducer = (state, action) => {
                 newUploadFile = [...notTbmFileList, findTbmFile];
             }
             return {...state, uploadList: structuredClone(newUploadFile)}
+        
+        case "PROJECT_OPTION":
+            const projectOptions = [];
+            ObjChk.ensureArray(action.list).forEach(item => {
+                projectOptions.push(
+                    {value: item.jno, label: item.project_nm},
+                );
+            });
+            
+            return {...state, tableProjectOptions: structuredClone(projectOptions)};
 
         default:
             return state;

--- a/src/component/module/SelectInput.jsx
+++ b/src/component/module/SelectInput.jsx
@@ -1,0 +1,71 @@
+import { useState, useEffect, useRef } from 'react';
+import Select from 'react-select';
+
+const SelectInput = ({ options, defaultValue, onChange }) => {
+    const scrollContainerRef = useRef(null);
+    // select 드롭다운 오픈 여부
+    const [menuOpen, setMenuOpen] = useState(false);
+
+    const [selectOption, setSelectOption] = useState();
+
+
+    const selectOnChange = (e) => {
+        setSelectOption(e);
+        onChange(e.value);
+    };
+
+    // 드롭다운 닫기
+    const handleScroll = () => {
+        setMenuOpen(false);
+    };
+
+    // 드롭다운 오픈시 실행
+    const handleMenuOpen = () => {
+        setMenuOpen(true);
+        scrollContainerRef.current = document.getElementById("table-container");
+        if (scrollContainerRef.current) {
+            scrollContainerRef.current.addEventListener("scroll", handleScroll, { once: true });
+        }
+    };
+
+    // 드롭다운 닫힐시 실행
+    const handleMenuClose = () => {
+        setMenuOpen(false);
+        if (scrollContainerRef.current) {
+            scrollContainerRef.current.removeEventListener("scroll", handleScroll);
+        }
+    };
+
+    useEffect(() => {
+        setSelectOption(options.find(opt => opt.value === defaultValue));
+    }, [options, defaultValue]);
+
+    return (
+        <div>
+            <Select
+                onChange={selectOnChange}
+                options={options}
+                value={selectOption}
+                menuIsOpen={menuOpen}
+                onMenuOpen={handleMenuOpen}
+                onMenuClose={handleMenuClose}
+                menuPortalTarget={document.body}
+                menuPosition="fixed"
+                menuShouldBlockScroll={false}
+                styles={{
+                container: (provided) => ({
+                    ...provided,
+                    width: "100%",
+                    zIndex: 3,
+                }),
+                menuPortal: (base) => ({
+                    ...base,
+                    zIndex: 9999,
+                }),
+                }}
+            />
+        </div>
+    );
+    };
+
+export default SelectInput;

--- a/src/utils/Common.js
+++ b/src/utils/Common.js
@@ -39,6 +39,8 @@ export const Common = {
     },
     // '-'으로 핸드폰번호 포맷
     formatMobileNumber(phoneNumber) {
+      if(phoneNumber === null) return "";
+      
       const numbers = phoneNumber.replace(/\D/g, '');
   
       let formatted = '';
@@ -153,19 +155,36 @@ export const Common = {
             cleaned = cleaned.slice(0, 13);
         }
 
-          // 생년월일(6자리) 미만이면 그대로 반환
-          if (cleaned.length < 7) {
-              return cleaned;
-          }
-          
-          // 6자리보다 길면 앞 6자리는 그대로, 그 이후 첫 자리는 노출, 나머지는 마스킹 처리
-          const birth = cleaned.slice(0, 6);
-          const remainder = cleaned.slice(6);
+        // 생년월일(6자리) 미만이면 그대로 반환
+        if (cleaned.length < 7) {
+            return cleaned;
+        }
+        
+        // 6자리보다 길면 앞 6자리는 그대로, 그 이후 첫 자리는 노출, 나머지는 마스킹 처리
+        const birth = cleaned.slice(0, 6);
+        const remainder = cleaned.slice(6);
 
-          const visible = remainder.charAt(0);
-          const masked = '*'.repeat(remainder.length > 1 ? remainder.length - 1 : 0);
-          
-          return `${birth}-${visible}${masked}`;
+        const visible = remainder.charAt(0);
+        const masked = '*'.repeat(remainder.length > 1 ? remainder.length - 1 : 0);
+        
+        return `${birth}-${visible}${masked}`;
+    },
+    // 주민번호 마스킹(뒷자리)
+    maskResidentBackNumber(jumin) {
+        if(ObjChk.all(jumin)) return "";
+
+        // 모든 숫자가 아닌 문자는 제거
+        let cleaned = jumin.replace(/[^0-9*]/g, '');
+
+          if (cleaned.length > 7) {
+            cleaned = cleaned.slice(0, 7);
+        }
+        
+        // 6자리보다 길면 앞 6자리는 그대로, 그 이후 첫 자리는 노출, 나머지는 마스킹 처리
+        const visible = cleaned.charAt(0);
+        const masked = '*'.repeat(cleaned.length > 1 ? cleaned.length - 1 : 0);
+        
+        return `${visible}${masked}`;
     },
     // 특정길이 반환
     clipToMaxLength(size, str){
@@ -179,6 +198,7 @@ export const Common = {
             return str;
         }
     },
+    // 숫자 천 단위 ','
     formatNumber(input) {
       if (input === undefined || input === null) {
           return "";
@@ -198,7 +218,6 @@ export const Common = {
           }
       }
       
-      // 천 단위 콤마 삽입
       return numericStr.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     },
     sanitizeNumberInput(input) {


### PR DESCRIPTION
1. 리스트에서 해당 근로자가 근무한 프로젝트를 선택할 수 있도록 수정 -> TBM, 퇴직공제로 가져오는 데이터와 홍채인식기로 가져오는 데이터에는 프로젝트에 대한 정보가 없기 때문에 해당 현장의 디폴트 프로젝트를 기준으로하고 다른 프로젝트라면 변경을 한 후에 반영을 할 수 있도록 수정. 반영 후에는 수정불가
2. 테이블 전용으로 사용할 select component 추가
3. 테이블의 리스트 체크를 특정 상태값에서만 할 수도 있도록 수정
4. 전체 근로자 상세화면의 주민번호 입력폼 및 오류 수정 -> 붙여넣기, 드래그 후 삭제/입력시 입력한 내용이 마스킹으로 인하여 정상 저장이 되지 않는 오류가 있어 수정. 생년월일, 뒷자리 입력 폼을 분리.