### PR TITLE
ErrorBoundary 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ function App() {
     return (
         <div className="App">
             <AuthProvider>
-                {/* <ErrorBoundary> */}
+                <ErrorBoundary>
                     <Routes>
                         <Route path="/login" element={<Login />} />
                         <Route path="/error" element={<ErrorPage />} />
@@ -56,7 +56,7 @@ function App() {
                         {/* 잘못된 경로 */}
                         <Route path="*" element={<NotFound />} />
                     </Routes>
-                {/* </ErrorBoundary> */}
+                </ErrorBoundary>
             </AuthProvider>
             {/* 툴팁 전역 설정 */}
             <ReactTooltip id="highlightTooltip" delayShow={0} positionStrategy="fixed" style={{ zIndex: 99999 }}/>

--- a/src/component/error/ErrorBoundary.jsx
+++ b/src/component/error/ErrorBoundary.jsx
@@ -1,31 +1,41 @@
 // ErrorBoundary.jsx
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import ErrorPage from './ErrorPage';
+
+/**
+ * @description: 
+ * @author 작성자: 김진우
+ * @created 작성일: 2025-04-08
+ * @modified 최종 수정일: 2025-07-02
+ * @modifiedBy 최종 수정자: 김진우
+ * @modified Description: 
+ * 2025-07-02: <Navigate to="/error" replace /> -> <ErrorPage/> 변경
+ */
 
 class ErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  // 자식 컴포넌트 렌더링 중 에러 발생 시 상태 업데이트
-  static getDerivedStateFromError(error) {
-    return { hasError: true };
-  }
-
-  // 에러 발생 후 추가적인 처리를 위한 메서드: 로깅, 에러 리포트 등
-  componentDidCatch(error, errorInfo) {
-    console.error("Error caught in ErrorBoundary:", error, errorInfo);
-  }
-
-  render() {
-    // 에러 발생한 경우, /error 경로로 리디렉션
-    if (this.state.hasError) {
-      return <Navigate to="/error" replace />;
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false };
     }
-    // 에러가 없으면 정상적으로 자식 컴포넌트 렌더링
-    return this.props.children;
-  }
+
+    // 자식 컴포넌트 렌더링 중 에러 발생 시 상태 업데이트
+    static getDerivedStateFromError(error) {
+        return { hasError: true };
+    }
+
+    // 에러 발생 후 추가적인 처리를 위한 메서드: 로깅, 에러 리포트 등
+    componentDidCatch(error, errorInfo) {
+        console.error("Error caught in ErrorBoundary:", error, errorInfo);
+    }
+
+    render() {
+        // 에러 발생한 경우, /error 경로로 리디렉션
+        if (this.state.hasError) {
+            return <ErrorPage/>;
+        }
+        // 에러가 없으면 정상적으로 자식 컴포넌트 렌더링
+        return this.props.children;
+    }
 }
 
 export default ErrorBoundary;


### PR DESCRIPTION
에러 발생 시 <Navigate /> 대신 <ErrorPage /> 직접 렌더하도록 변경

React의 ErrorBoundary는 예외 발생 시 비정상적인 렌더링 흐름에서 작동하므로, <Navigate />를 사용할 경우 Router context가 깨져 리디렉션이 실패할 수 있음. 따라서 안정적인 에러 처리를 위해 <ErrorPage />를 직접 렌더하는 방식으로 수정.