### PR TITLE
[일정관리, 비교] 전체 일정 추가 및 수정 권한 변경 및 일일근로자 비교 테이블 수정 

### DIFF
--- a/src/component/layout/content/management/code/SubCodeList.jsx
+++ b/src/component/layout/content/management/code/SubCodeList.jsx
@@ -483,6 +483,7 @@ const headerStyle = {
 const textInputStyle = {
     width: "100%",
     textAlign: "left",
+    height: "2rem",
 }
 
 const colorInputStyle = {

--- a/src/component/layout/content/management/compare/DailyCompare.jsx
+++ b/src/component/layout/content/management/compare/DailyCompare.jsx
@@ -134,11 +134,15 @@ const DailyCompare = () => {
             if (errs.length !== 0){
 
                 let workers = "\n";
-                errs.map((err) => {
-                    workers += `${err.user_nm}\n`;
+                errs.map((err, idx) => {
+                    if (idx < 5){
+                        workers += `${err.user_nm}\n`;
+                    }else if (idx === 5){
+                        workers += `...\n`;
+                    }
                 })
 
-                setModalText(`프로젝트 미설정 근로자 ${workers}\n설정 후 다시 시도해주세요.`);
+                setModalText(`프로젝트 미설정 근로자 ${workers}\n프로젝트 설정 후 다시 시도해주세요.\n`);
                 setIsModal(true);
                 return;
             }

--- a/src/component/layout/content/management/compare/DailyCompareReducer.js
+++ b/src/component/layout/content/management/compare/DailyCompareReducer.js
@@ -9,10 +9,10 @@ const DailyCompareReducer = (state, action) => {
             const newcompareList = compareList.map((item, idx) => {
                 return {
                     ...item, 
-                    worker_in_time: dateUtil.formatDateTime(item.worker_in_time),
-                    worker_out_time: dateUtil.formatDateTime(item.worker_out_time),
-                    deduction_in_time:dateUtil.formatDateTime(item.deduction_in_time),
-                    deduction_out_time: dateUtil.formatDateTime(item.deduction_out_time),
+                    worker_in_time: dateUtil.formatTimeHHMM(item.worker_in_time),
+                    worker_out_time: dateUtil.formatTimeHHMM(item.worker_out_time),
+                    deduction_in_time:dateUtil.formatTimeHHMM(item.deduction_in_time),
+                    deduction_out_time: dateUtil.formatTimeHHMM(item.deduction_out_time),
                     index: idx,
                 };
             });

--- a/src/component/layout/content/management/schedule/Schedule.jsx
+++ b/src/component/layout/content/management/schedule/Schedule.jsx
@@ -143,14 +143,15 @@ const Schedule = () => {
             setCancelDay(null);
         }
 
+
     }
 
     // 취소기한 별 날짜 여부 체크: jno
     const checkAllowDate = (date) => {
 
         // 오늘날짜에서 마감취소기간을 뺀 최소 허용 기간 구하기
-        const allowDate = dateUtil.diffDay(new Date(dateUtil.now()), cancelDay);
-        
+        const now = new Date();
+        const allowDate = dateUtil.diffDay(new Date(now.getFullYear(), now.getMonth(), now.getDate()), cancelDay);
         const compDate = new Date(date);
 
         // 만약 선택한 날짜가 최소허용기간 보다 적으면 false 반환
@@ -565,7 +566,6 @@ const Schedule = () => {
         setIsAddDetailModal(true);
     }
 
-
     // 휴무일 저장
     const onClicklRestSave = async(item) => {
         const rests = [];
@@ -758,7 +758,6 @@ const Schedule = () => {
     }
 
     /***** useEffect *****/
-
     // 셀렉트 연, 월 생성
     useEffect(() => {
         const yearOptions = [];
@@ -806,7 +805,11 @@ const Schedule = () => {
 
     // 프로젝트 변경 시 마감취소기한 조회
     useEffect(() => {
-        getProjectSetting();
+        if ( project === null ){
+            setCancelDay(null);
+        }else {
+            getProjectSetting();
+        }
     }, [project])
 
     return(
@@ -976,7 +979,7 @@ const Schedule = () => {
                                                         verticalAlign: "top", 
                                                         textAlign: "left", 
                                                         padding: "10px", 
-                                                        paddingBottom:"30px",
+                                                        paddingBottom: project ? "30px": null,
                                                         backgroundColor: isSameDay(new Date(), item) ? "#f9fdd7" : "",
                                                     }}
                                                 >   

--- a/src/component/layout/content/management/site/DetailProject.jsx
+++ b/src/component/layout/content/management/site/DetailProject.jsx
@@ -15,6 +15,7 @@ import Modal from "../../../../module/Modal";
 import OrganizationModal from "../../../../module/modal/OrganizationModal";
 import AddDetailSchedule from "../schedule/AddDetailSchedule";
 import DetailSchedule from "../schedule/DetailSchedule";
+import { roleGroup, useUserRole } from "../../../../../utils/hooks/useUserRole";
 
 /**
  * @description: 프로젝트 상세 컴포넌트
@@ -40,6 +41,12 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
     const { getData, selectedDate } = useContext(SiteContext);
     const { user } = useAuth();
     const navigate = useNavigate();
+
+    // 작업 내용 추가 및 수정 권한
+    // 권한 체크
+    const { isRoleValid } = useUserRole();
+    // 전체 프로젝트 수정 권한
+    const scheduleRole = isRoleValid(roleGroup.SCHEDULE_MANAGER);
 
     // 작업내용 상세 모달
     const [isClickDateRest, setIsClickDateRest] = useState(false);
@@ -293,12 +300,16 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
                     {isEdit ? 
                         !isMain && <Button text={"삭제"} style={{marginLeft: "auto"}} onClick={() => onClickDeleteBtn(data.jno)}/>
                     :
-                        <>
+                    <>
+                        {scheduleRole ?
                             <Button style ={{marginLeft : "auto"}} text={"작업추가"} onClick={() => onClickAddSchedule()}></Button>
-                            <div className="grid-project-organization-container" onClick={onClickOrganization}>
-                                <img src={Organization} style={{width: "20px"}}/>
-                            </div>
-                        </>
+                        : 
+                            null 
+                        }
+                        <div className="grid-project-organization-container" onClick={onClickOrganization} style={scheduleRole ? null : { marginLeft:"auto"}}>
+                            <img src={Organization} style={{width: "20px"}}/>
+                        </div>
+                    </>
                     }
                 </div>
                 

--- a/src/component/module/SelectInput.jsx
+++ b/src/component/module/SelectInput.jsx
@@ -62,6 +62,16 @@ const SelectInput = ({ options, defaultValue, onChange }) => {
                     ...base,
                     zIndex: 9999,
                 }),
+                control: (provided, state) => ({
+                    ...provided,
+                    minHeight: "2.125rem",       // 최소 높이 조정
+                    height: "2.125rem",          // 전체 높이 강제 설정
+                }),
+                option: (provided, state) => ({
+                    ...provided,
+                    padding: "0.25rem 1rem",           // 내부 간격
+                    fontSize: "0.9rem",
+                })
                 }}
             />
         </div>

--- a/src/component/module/Table.jsx
+++ b/src/component/module/Table.jsx
@@ -1060,7 +1060,7 @@ const Table = forwardRef(({
                                             : item[col.itemName] === "W" ?
                                                 <div style={{display: "flex", alignItems: "center", justifyContent: "center"}}>
                                                     <img src={CompareWIcom} style={{width: "20px"}}/>
-                                                    <span style={{paddingLeft: "5px"}}>확인필요</span>
+                                                    <span style={{paddingLeft: "5px"}}>확인</span>
                                                 </div>
                                             : item[col.itemName] === "C" ?
                                                 <div style={{display: "flex", alignItems: "center", justifyContent: "center"}}>

--- a/src/utils/hooks/useUserRole.js
+++ b/src/utils/hooks/useUserRole.js
@@ -41,6 +41,11 @@ export const roleGroup = Object.freeze({
     NOTICE_ALL_MOD_MANAGER: [ // 다른 사람이 작성한 공지사항 수정, 삭제 권한
         userRole.SYSTEM_ADMIN.code,
         userRole.SUPER_ADMIN.code,
+    ],
+    SCHEDULE_MANAGER : [ // 일정관리 전체 일정 수정 권한
+        userRole.SYSTEM_ADMIN.code,
+        userRole.SUPER_ADMIN.code,
+        userRole.ADMIN.code,
     ]
 
 });


### PR DESCRIPTION
1. 일정관리 전체 일정 추가 및 수정 권한 관리자만 되도록 변경
2. 일일근로자비교테이블에 인식기명 추가, 날짜 제외한 시간만 표시 및 selectbox크기 조정
3. 일일근로자가 많은 경우 모달이 너무 길어져 ...으로 생략 